### PR TITLE
style(Blazor): standardize CRUD page route parameters and misc cleanup

### DIFF
--- a/NjordinSight.Web/Pages/AccountComposites/Create.razor
+++ b/NjordinSight.Web/Pages/AccountComposites/Create.razor
@@ -51,13 +51,12 @@
 
 @code {
     [Parameter]
-    public Guid RequestGuid { get; set; }
+    public Guid RequestGuid { get; init; }
 
     private IEnumerable<LookupModel<int, string>> AccountDtos { get; set; }
 
     private AccountCompositeDto ViewModel { get; set; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/AccountComposites/Detail.razor
+++ b/NjordinSight.Web/Pages/AccountComposites/Detail.razor
@@ -1,4 +1,4 @@
-﻿@page "/composites/{AccountCompositeId:int}/detail"
+﻿@page "/composites/{ModelId:int}/detail"
 
 @inherits ModelDetail<AccountComposite>
 
@@ -62,13 +62,12 @@
 
 @code {
     [Parameter]
-    public int AccountCompositeId { get; set; }
+    public int ModelId { get; init; }
 
     private IEnumerable<LookupModel<int, string>> Accounts { get; set; }
 
     private AccountCompositeDto ViewModel { get; set; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
 
@@ -76,7 +75,7 @@
 
         try
         {
-            var compositeQuery = Controller.ReadAsync(AccountCompositeId);
+            var compositeQuery = Controller.ReadAsync(ModelId);
             var accountsQuery = Controller.ReferenceQueries.GetAccountDTOsAsync();
 
             Task dataTasks = Task.WhenAll(compositeQuery, accountsQuery);

--- a/NjordinSight.Web/Pages/AccountComposites/Edit.razor
+++ b/NjordinSight.Web/Pages/AccountComposites/Edit.razor
@@ -58,13 +58,12 @@
 
 @code {
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
     private IEnumerable<LookupModel<int, string>> Accounts { get; set; }
 
     private AccountCompositeDto ViewModel { get; set; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/Accounts/BankTransactions/Edit.razor
+++ b/NjordinSight.Web/Pages/Accounts/BankTransactions/Edit.razor
@@ -1,4 +1,4 @@
-﻿@page "/accounts/{AccountId:int}/edit/bank-transactions"
+﻿@page "/accounts/{ModelId:int}/edit/bank-transactions"
 
 @inherits ModelListPage<BankTransaction>
 
@@ -95,7 +95,7 @@
 
 @code {
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
     private IEnumerable<LookupModel<int, string>> TransactionCodes { get; set; }
 

--- a/NjordinSight.Web/Pages/Accounts/BankTransactions/Index.razor
+++ b/NjordinSight.Web/Pages/Accounts/BankTransactions/Index.razor
@@ -1,4 +1,4 @@
-﻿@page "/accounts/{AccountId:int}/detail/bank-transactions"
+﻿@page "/accounts/{ModelId:int}/detail/bank-transactions"
 
 @inherits ModelPage<BankTransaction>
 
@@ -58,7 +58,7 @@
 
 @code {
     [Parameter]
-    public int AccountId { get; set; }
+    public int ModelId { get; init; }
 
     private IList<BankTransaction> BankTransactions { get; set; }
 
@@ -81,7 +81,7 @@
                             Caption = string.Format(
                                 Strings.Caption_NavigateBackTo,
                                 ModelMetadata.GetAttribute<Account, NounAttribute>()?.GetSingular()),
-                            UriStem = $"{IndexUriRelativePath}/{AccountId}/detail"
+                            UriStem = $"{IndexUriRelativePath}/{ModelId}/detail"
                         }
                     },
                     { 1, new MenuItem()
@@ -89,7 +89,7 @@
                             IconKey = "pencil",
                             Caption = string.Format(
                                 Strings.Caption_EditMany, ModelNoun?.GetPlural()),
-                            UriStem = $"{IndexUriRelativePath}/{AccountId}/edit/bank-transactions"
+                            UriStem = $"{IndexUriRelativePath}/{ModelId}/edit/bank-transactions"
                         }
                     }
                 }
@@ -102,7 +102,7 @@
             ParentAccount = (
                 await Controller.ReferenceQueries
                     .GetSingleAsync<Account>(
-                        predicate: a => a.AccountId == AccountId,
+                        predicate: a => a.AccountId == ModelId,
                         path: a => a.AccountNavigation)).Value;
 
             var initResult = await Controller.ForParent(ParentAccount.AccountId);
@@ -136,10 +136,10 @@
     /// <summary>
     /// Gets the index uri stem to this page.
     /// </summary>
-    private string IndexUriRelative => $"{IndexUriRelativePath}/{AccountId}/edit/broker-transactions";
+    private string IndexUriRelative => $"{IndexUriRelativePath}/{ModelId}/edit/broker-transactions";
 
     private void Cancel_OnClick() => NavigationHelper
-        .NavigateTo($"{IndexUriRelativePath}/{AccountId}/detail");
+        .NavigateTo($"{IndexUriRelativePath}/{ModelId}/detail");
 
     private string GetLookupDisplayName(IEnumerable<LookupModel<int, string>> lookupModels, int id) =>
         lookupModels.FirstOrDefault(x => x.Key == id)?.Display ?? string.Empty;

--- a/NjordinSight.Web/Pages/Accounts/BrokerTransactions/Edit.razor
+++ b/NjordinSight.Web/Pages/Accounts/BrokerTransactions/Edit.razor
@@ -1,4 +1,4 @@
-﻿@page "/accounts/{AccountId:int}/edit/broker-transactions"
+﻿@page "/accounts/{ModelId:int}/edit/broker-transactions"
 
 @inherits ModelPage<BrokerTransaction>
 
@@ -182,7 +182,7 @@
 
 @code {
     [Parameter]
-    public int AccountId { get; set; }
+    public int ModelId { get; init; }
 
     private IEnumerable<BrokerTransaction> Entries { get; set; }
 
@@ -212,9 +212,9 @@
                 .GetBrokerTransactionCodeDTOsAsync();
             var parentAccountTask = Controller.ReferenceQueries
                 .GetSingleAsync<Account>(
-                    predicate: x => x.AccountId == AccountId,
+                    predicate: x => x.AccountId == ModelId,
                     path: x => x.AccountNavigation);
-            var loadRecordsTask = Controller.LoadRecordsAsync(parentId: AccountId);
+            var loadRecordsTask = Controller.LoadRecordsAsync(parentId: ModelId);
 
             var initTasks = Task.WhenAll(
                 securityDTOsTask,
@@ -257,7 +257,7 @@
     /// <summary>
     /// Gets the index uri stem to this page.
     /// </summary>
-    private string IndexUriRelative => $"{IndexUriRelativePath}/{AccountId}/detail/broker-transactions";
+    private string IndexUriRelative => $"{IndexUriRelativePath}/{ModelId}/detail/broker-transactions";
 
     private async Task AddNewAsync(MouseEventArgs args)
     {
@@ -276,7 +276,7 @@
 
     private void Cancel_OnClick() => 
         NavigationHelper.NavigateTo(
-            $"{IndexUriRelativePath}/{AccountId}/detail/broker-transactions");
+            $"{IndexUriRelativePath}/{ModelId}/detail/broker-transactions");
 
     private async Task TransactionCode_OnValueChanged(BrokerTransaction model, int newId)
     {

--- a/NjordinSight.Web/Pages/Accounts/BrokerTransactions/Index.razor
+++ b/NjordinSight.Web/Pages/Accounts/BrokerTransactions/Index.razor
@@ -1,4 +1,4 @@
-﻿@page "/accounts/{AccountId:int}/detail/broker-transactions"
+﻿@page "/accounts/{ModelId:int}/detail/broker-transactions"
 
 @inherits ModelPage<BrokerTransaction>
 
@@ -104,7 +104,7 @@
 
 @code {
     [Parameter]
-    public int AccountId { get; set; }
+    public int ModelId { get; init; }
 
     private IEnumerable<BrokerTransaction> Entries { get; set; }
 
@@ -131,7 +131,7 @@
                             Caption = string.Format(
                                 Strings.Caption_NavigateBackTo,
                                 ModelMetadata.GetAttribute<Account, NounAttribute>()?.GetSingular()),
-                            UriStem = $"{IndexUriRelativePath}/{AccountId}/detail"
+                            UriStem = $"{IndexUriRelativePath}/{ModelId}/detail"
                         }
                     },
                     { 1, new MenuItem()
@@ -139,7 +139,7 @@
                             IconKey = "pencil",
                             Caption = string.Format(
                                 Strings.Caption_EditMany, ModelNoun?.GetPlural()),
-                            UriStem = $"{IndexUriRelativePath}/{AccountId}/edit/broker-transactions"
+                            UriStem = $"{IndexUriRelativePath}/{ModelId}/edit/broker-transactions"
                         }
                     }
                 }
@@ -155,9 +155,9 @@
                 .GetBrokerTransactionCodeDTOsAsync();
             var parentAccountTask = Controller.ReferenceQueries
                 .GetSingleAsync<Account>(
-                    predicate: x => x.AccountId == AccountId,
+                    predicate: x => x.AccountId == ModelId,
                     path: x => x.AccountNavigation);
-            var loadRecordsTask = Controller.LoadRecordsAsync(parentId: AccountId);
+            var loadRecordsTask = Controller.LoadRecordsAsync(parentId: ModelId);
 
             var initTasks = Task.WhenAll(
                 securityDTOsTask,
@@ -195,8 +195,8 @@
     /// <summary>
     /// Gets the index uri stem to this page.
     /// </summary>
-    private string IndexUriRelative => $"{IndexUriRelativePath}/{AccountId}/edit/broker-transactions";
+    private string IndexUriRelative => $"{IndexUriRelativePath}/{ModelId}/edit/broker-transactions";
 
     private void Cancel_OnClick() => NavigationHelper
-        .NavigateTo($"{IndexUriRelativePath}/{AccountId}/detail");
+        .NavigateTo($"{IndexUriRelativePath}/{ModelId}/detail");
 }

--- a/NjordinSight.Web/Pages/Accounts/Create.razor
+++ b/NjordinSight.Web/Pages/Accounts/Create.razor
@@ -42,9 +42,6 @@
 </ThemedComponent>
 
 @code {
-    /// <summary>
-    /// Gets or sets the unique identifier for the creation action.
-    /// </summary>
     [Parameter]
     public Guid RequestGuid { get; init; }
 
@@ -52,7 +49,6 @@
 
     private AccountDto ViewModel { get; set; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/Accounts/Detail.razor
+++ b/NjordinSight.Web/Pages/Accounts/Detail.razor
@@ -1,4 +1,4 @@
-﻿@page "/accounts/{AccountId:int}/detail"
+﻿@page "/accounts/{ModelId:int}/detail"
 
 @inherits ModelDetail<Account>
 
@@ -56,13 +56,12 @@
 
 @code {
     [Parameter]
-    public int AccountId { get; set; }
+    public int ModelId { get; init; }
 
     private IEnumerable<LookupModel<int, string>> Custodians { get; set; }
 
     private AccountDto ViewModel { get; set; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
 
@@ -70,7 +69,7 @@
 
         try
         {
-            var accountQuery = await Controller.ReadAsync(AccountId);
+            var accountQuery = await Controller.ReadAsync(ModelId);
             Model = accountQuery.Value;
 
             ActionMenu = new()
@@ -110,7 +109,7 @@
                         Caption = string.Format(
                                 Strings.Caption_ViewMany,
                                 ModelMetadata.GetAttribute<BankTransaction, NounAttribute>()?.GetPlural()),
-                        UriStem = $"{FormatDetailUri(AccountId)}/bank-transactions"
+                        UriStem = $"{FormatDetailUri(ModelId)}/bank-transactions"
                     });
 
             // Add view broker transactions menu item.

--- a/NjordinSight.Web/Pages/Accounts/Edit.razor
+++ b/NjordinSight.Web/Pages/Accounts/Edit.razor
@@ -1,4 +1,4 @@
-﻿@page "/accounts/{AccountId:int}/edit"
+﻿@page "/accounts/{ModelId:int}/edit"
 
 @inherits ModelDetail<Account>
 
@@ -39,17 +39,13 @@
 </ThemedComponent>
 
 @code {
-    /// <summary>
-    /// Gets or sets the identifier for the <see cref="Account" /> worked using this page.
-    /// </summary>
     [Parameter]
     public int ModelId { get; init; }
 
     private IEnumerable<LookupModel<int, string>> Custodians { get; set; }
 
     private AccountDto ViewModel { get; set; }
-
-    /// <inheritdoc/>
+    
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/Accounts/Index.razor
+++ b/NjordinSight.Web/Pages/Accounts/Index.razor
@@ -122,7 +122,6 @@
 
 
 @code {
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         ActionMenu = GetDefaultIndexMenu();

--- a/NjordinSight.Web/Pages/Accounts/Wallets/Edit.razor
+++ b/NjordinSight.Web/Pages/Accounts/Wallets/Edit.razor
@@ -1,4 +1,4 @@
-﻿@page "/accounts/{AccountId:int}/edit/wallets"
+﻿@page "/accounts/{ModelId:int}/edit/wallets"
 
 @inherits ModelListPage<AccountWallet>
 
@@ -92,7 +92,7 @@
 
 @code {
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
     private IList<AccountWallet> Wallets { get; set; }
 

--- a/NjordinSight.Web/Pages/Attributes/Create.razor
+++ b/NjordinSight.Web/Pages/Attributes/Create.razor
@@ -122,13 +122,12 @@
 
 @code {
     [Parameter]
-    public Guid RequestGuid { get; set; }
+    public Guid RequestGuid { get; init; }
 
     private ModelAttributeDto ViewModel { get; set; }
 
     private IEnumerable<LookupModel<string, string>> AttributeScopeDtos { get; set; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/Attributes/Detail.razor
+++ b/NjordinSight.Web/Pages/Attributes/Detail.razor
@@ -74,11 +74,10 @@
 
 @code {
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
     private ModelAttributeDto ViewModel { get; set; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
 

--- a/NjordinSight.Web/Pages/Attributes/Edit.razor
+++ b/NjordinSight.Web/Pages/Attributes/Edit.razor
@@ -127,13 +127,12 @@
 
 @code {
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
     private ModelAttributeDto ViewModel { get; set; }
 
     private IEnumerable<LookupModel<string, string>> AttributeScopeDtos { get; set; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/Attributes/Index.razor
+++ b/NjordinSight.Web/Pages/Attributes/Index.razor
@@ -45,7 +45,6 @@
 </ThemedComponent>
 
 @code {
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         ActionMenu = GetDefaultIndexMenu();

--- a/NjordinSight.Web/Pages/BankTransactionCodes/Create.razor
+++ b/NjordinSight.Web/Pages/BankTransactionCodes/Create.razor
@@ -36,22 +36,9 @@
 </ThemedComponent>
 
 @code {
-    /// <summary>
-    /// Gets or sets the identifier for the <see cref="BankTransactionCode" /> worked using this
-    /// page.
-    /// </summary>
-    [Parameter]
-    public int ModelId { get; set; }
-
-    /// <summary>
-    /// Gets or sets the unique identifier for the model creation request.
-    /// </summary>
     [Parameter]
     public Guid RequestGuid { get; init; }
 
-    /// <summary>
-    /// Gets or sets the <see cref="BankTransactionCodeDto" /> worked by this page.
-    /// </summary>
     private BankTransactionCodeDto ViewModel { get; set; }
 
     protected override async Task OnInitializedAsync()

--- a/NjordinSight.Web/Pages/BankTransactionCodes/Detail.razor
+++ b/NjordinSight.Web/Pages/BankTransactionCodes/Detail.razor
@@ -57,7 +57,7 @@
 
 @code {
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
     private BankTransactionCodeDto ViewModel { get; set; }
 

--- a/NjordinSight.Web/Pages/BankTransactionCodes/Edit.razor
+++ b/NjordinSight.Web/Pages/BankTransactionCodes/Edit.razor
@@ -38,17 +38,10 @@
 </ThemedComponent>
 
 @code {
-    /// <summary>
-    /// Gets or sets the identifier for the <see cref="BankTransactionCode" /> worked on this page.
-    /// </summary>
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
-    /// <summary>
-    /// Gets or sets the <see cref="BankTransactionCodeDto" /> worked by this page.
-    /// </summary>
     private BankTransactionCodeDto ViewModel { get; set; }
-
 
     protected override async Task OnInitializedAsync()
     {

--- a/NjordinSight.Web/Pages/BankTransactionCodes/Index.razor
+++ b/NjordinSight.Web/Pages/BankTransactionCodes/Index.razor
@@ -46,7 +46,6 @@
 </ThemedComponent>
 
 @code {
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         ActionMenu = GetDefaultIndexMenu();

--- a/NjordinSight.Web/Pages/BrokerTransactionCodes/Create.razor
+++ b/NjordinSight.Web/Pages/BrokerTransactionCodes/Create.razor
@@ -36,15 +36,9 @@
 </ThemedComponent>
 
 @code {
-    /// <summary>
-    /// Gets or sets the unique identifier for the model creation request.
-    /// </summary>
     [Parameter]
     public Guid RequestGuid { get; init; }
 
-    /// <summary>
-    /// Gets or sets the <see cref="BrokerTransactionCodeDto" /> worked by this page.
-    /// </summary>
     private BrokerTransactionCodeDto ViewModel { get; set; }
 
     protected override async Task OnInitializedAsync()

--- a/NjordinSight.Web/Pages/BrokerTransactionCodes/Detail.razor
+++ b/NjordinSight.Web/Pages/BrokerTransactionCodes/Detail.razor
@@ -55,7 +55,7 @@
 
 @code {
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
     private BrokerTransactionCodeDto ViewModel { get; set; }
 

--- a/NjordinSight.Web/Pages/BrokerTransactionCodes/Edit.razor
+++ b/NjordinSight.Web/Pages/BrokerTransactionCodes/Edit.razor
@@ -38,12 +38,8 @@
 </ThemedComponent>
 
 @code {
-    /// <summary>
-    /// Gets or sets the identifier for the <see cref="BankTransactionCode" /> worked using this
-    /// page.
-    /// </summary>
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
     /// <summary>
     /// Gets or sets the <see cref="BrokerTransactionCodeDto" /> worked by this page.

--- a/NjordinSight.Web/Pages/Countries/Create.razor
+++ b/NjordinSight.Web/Pages/Countries/Create.razor
@@ -44,15 +44,11 @@
 
 
 @code {
-    /// <summary>
-    /// Gets or sets the unique identifier for the creation action.
-    /// </summary>
     [Parameter]
     public Guid RequestGuid { get; init; }
 
     private Country ViewModel { get; set; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/Countries/Detail.razor
+++ b/NjordinSight.Web/Pages/Countries/Detail.razor
@@ -48,7 +48,7 @@
 
 @code {
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
     private CountryDto ViewModel { get; set; }
 

--- a/NjordinSight.Web/Pages/Countries/Edit.razor
+++ b/NjordinSight.Web/Pages/Countries/Edit.razor
@@ -41,7 +41,7 @@
 
 @code {
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
     private CountryDto ViewModel { get; set; }
 

--- a/NjordinSight.Web/Pages/Countries/Index.razor
+++ b/NjordinSight.Web/Pages/Countries/Index.razor
@@ -61,7 +61,6 @@
 </ThemedComponent>
 
 @code {
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         ActionMenu = GetDefaultIndexMenu();

--- a/NjordinSight.Web/Pages/Custodians/Index.razor
+++ b/NjordinSight.Web/Pages/Custodians/Index.razor
@@ -41,7 +41,6 @@
 </ThemedComponent>
 
 @code {
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         ActionMenu = new()

--- a/NjordinSight.Web/Pages/InvestmentModels/Create.razor
+++ b/NjordinSight.Web/Pages/InvestmentModels/Create.razor
@@ -37,9 +37,6 @@
 </ThemedComponent>
 
 @code{
-    /// <summary>
-    /// Gets or sets the unique identifier for the model creation request.
-    /// </summary>
     [Parameter]
     public Guid RequestGuid { get; init; }
 

--- a/NjordinSight.Web/Pages/InvestmentModels/Detail.razor
+++ b/NjordinSight.Web/Pages/InvestmentModels/Detail.razor
@@ -48,7 +48,7 @@
 
 @code{
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
     private InvestmentModelDto ViewModel { get; set; }
 

--- a/NjordinSight.Web/Pages/InvestmentModels/Edit.razor
+++ b/NjordinSight.Web/Pages/InvestmentModels/Edit.razor
@@ -41,15 +41,9 @@
 </ThemedComponent>
 
 @code {
-    /// <summary>
-    /// Gets or sets the identifier for the <see cref="InvestmentStrategy" /> worked on this page.
-    /// </summary>
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
-    /// <summary>
-    /// Gets or sets the <see cref="InvestmentModelDto" /> worked by this page.
-    /// </summary>
     private InvestmentModelDto ViewModel { get; set; }
 
     protected override async Task OnInitializedAsync()

--- a/NjordinSight.Web/Pages/InvestmentModels/Index.razor
+++ b/NjordinSight.Web/Pages/InvestmentModels/Index.razor
@@ -37,7 +37,6 @@
 </ThemedComponent>
 
 @code {
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         ActionMenu = GetDefaultIndexMenu();

--- a/NjordinSight.Web/Pages/MarketIndices/Create.razor
+++ b/NjordinSight.Web/Pages/MarketIndices/Create.razor
@@ -44,13 +44,9 @@
 
 
 @code {
-    /// <summary>
-    /// Gets or sets the unique identifier for the creation action.
-    /// </summary>
     [Parameter]
     public Guid RequestGuid { get; init; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/MarketIndices/Detail.razor
+++ b/NjordinSight.Web/Pages/MarketIndices/Detail.razor
@@ -1,4 +1,4 @@
-﻿@page "/market-indices/{IndexId:int}/detail"
+﻿@page "/market-indices/{ModelId:int}/detail"
 
 @inherits ModelDetail<MarketIndex>
 
@@ -33,20 +33,16 @@
 
 
 @code{
-    /// <summary>
-    /// Gets or sets the identifier for the <see cref="MarketIndex" /> worked using this page.
-    /// </summary>
     [Parameter]
-    public int IndexId { get; set; }
-
-    /// <inheritdoc/>
+    public int ModelId { get; init; }
+  
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;
 
         try
         {
-            var modelQuery = await Controller.ReadAsync(IndexId);
+            var modelQuery = await Controller.ReadAsync(ModelId);
             if(modelQuery.Value is MarketIndex index)
                 Model = index;
 

--- a/NjordinSight.Web/Pages/MarketIndices/Edit.razor
+++ b/NjordinSight.Web/Pages/MarketIndices/Edit.razor
@@ -49,13 +49,9 @@
 
 
 @code {
-    /// <summary>
-    /// Gets or sets the identifier for the <see cref="MarketIndex" /> worked using this page.
-    /// </summary>
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/MarketIndices/Index.razor
+++ b/NjordinSight.Web/Pages/MarketIndices/Index.razor
@@ -47,7 +47,6 @@
 
 
 @code {
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         ActionMenu = GetDefaultIndexMenu();

--- a/NjordinSight.Web/Pages/MarketIndices/Rates/Edit.razor
+++ b/NjordinSight.Web/Pages/MarketIndices/Rates/Edit.razor
@@ -157,7 +157,6 @@
 
     #endregion
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/MarketIndices/Rates/Index.razor
+++ b/NjordinSight.Web/Pages/MarketIndices/Rates/Index.razor
@@ -113,7 +113,6 @@
 
     #endregion
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/ReportConfigurations/Create.razor
+++ b/NjordinSight.Web/Pages/ReportConfigurations/Create.razor
@@ -44,13 +44,9 @@
 
 
 @code {
-    /// <summary>
-    /// Gets or sets the unique identifier for the creation action.
-    /// </summary>
     [Parameter]
     public Guid RequestGuid { get; init; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/ReportConfigurations/Detail.razor
+++ b/NjordinSight.Web/Pages/ReportConfigurations/Detail.razor
@@ -32,13 +32,9 @@
 
 
 @code {
-    /// <summary>
-    /// Gets or sets the identifier for the <see cref="ReportConfiguration" /> worked using this page.
-    /// </summary>
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/ReportConfigurations/Edit.razor
+++ b/NjordinSight.Web/Pages/ReportConfigurations/Edit.razor
@@ -58,13 +58,9 @@
 
 
 @code {
-    /// <summary>
-    /// Gets or sets the identifier for the <see cref="ReportConfiguration" /> worked using this page.
-    /// </summary>
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/ReportConfigurations/Index.razor
+++ b/NjordinSight.Web/Pages/ReportConfigurations/Index.razor
@@ -45,7 +45,6 @@
 
 
 @code {
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         ActionMenu = GetDefaultIndexMenu();

--- a/NjordinSight.Web/Pages/ReportStyleSheet/Create.razor
+++ b/NjordinSight.Web/Pages/ReportStyleSheet/Create.razor
@@ -50,7 +50,6 @@
     [Parameter]
     public Guid RequestGuid { get; init; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/ReportStyleSheet/Detail.razor
+++ b/NjordinSight.Web/Pages/ReportStyleSheet/Detail.razor
@@ -32,13 +32,9 @@
 
 
 @code {
-    /// <summary>
-    /// Gets or sets the identifier for the <see cref="ReportConfiguration" /> worked using this page.
-    /// </summary>
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/ReportStyleSheet/Edit.razor
+++ b/NjordinSight.Web/Pages/ReportStyleSheet/Edit.razor
@@ -58,13 +58,9 @@
 
 
 @code {
-    /// <summary>
-    /// Gets or sets the identifier for the <see cref="ReportConfiguration" /> worked using this page.
-    /// </summary>
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/ReportStyleSheet/Index.razor
+++ b/NjordinSight.Web/Pages/ReportStyleSheet/Index.razor
@@ -45,7 +45,6 @@
 
 
 @code {
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         ActionMenu = GetDefaultIndexMenu();

--- a/NjordinSight.Web/Pages/Securities/Create.razor
+++ b/NjordinSight.Web/Pages/Securities/Create.razor
@@ -46,9 +46,6 @@
 </ThemedComponent>
 
 @code {
-    /// <summary>
-    /// Gets or sets the unique identifier for the creation action.
-    /// </summary>
     [Parameter]
     public Guid RequestGuid { get; init; }
 
@@ -60,7 +57,6 @@
 
     private SecurityDto ViewModel { get; set; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
 

--- a/NjordinSight.Web/Pages/Securities/Detail.razor
+++ b/NjordinSight.Web/Pages/Securities/Detail.razor
@@ -1,4 +1,4 @@
-﻿@page "/securities/{SecurityId:int}/detail"
+﻿@page "/securities/{ModelId:int}/detail"
 
 @inherits ModelDetail<Security>
 
@@ -110,7 +110,7 @@
 
 @code {
     [Parameter]
-    public int SecurityId { get; set; }
+    public int ModelId { get; init; }
 
     private IEnumerable<LookupModel<int, string>> Exchanges { get; set; }
 
@@ -122,7 +122,6 @@
 
     private SecurityDto ViewModel { get; set; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
 
@@ -143,7 +142,7 @@
             var issuersQuery = Controller.ReferenceQueries
                 .GetManyAsync<Security>(x => (x.Issuer ?? string.Empty) != string.Empty);
 
-            var securityQuery = Controller.ReadAsync(SecurityId);
+            var securityQuery = Controller.ReadAsync(ModelId);
 
             var symbolTypesQuery = Controller.ReferenceQueries
                 .GetDtosAsync<SecuritySymbolType, int, string>(

--- a/NjordinSight.Web/Pages/Securities/Edit.razor
+++ b/NjordinSight.Web/Pages/Securities/Edit.razor
@@ -143,7 +143,7 @@
 
 @code {
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
     private IEnumerable<LookupModel<int, string>> Exchanges { get; set; }
 
@@ -157,7 +157,6 @@
 
     private SecurityDto ViewModel { get; set; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
 

--- a/NjordinSight.Web/Pages/Securities/Index.razor
+++ b/NjordinSight.Web/Pages/Securities/Index.razor
@@ -102,7 +102,6 @@
 
     private IEnumerable<LookupModel<int, string>> SecurityTypes { get; set; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         ActionMenu = GetDefaultIndexMenu();

--- a/NjordinSight.Web/Pages/Securities/Prices/Edit.razor
+++ b/NjordinSight.Web/Pages/Securities/Prices/Edit.razor
@@ -169,7 +169,6 @@
 
     private bool UpodateLoading() => SecurityLookup is null || Entries is null;
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/Securities/Prices/Index.razor
+++ b/NjordinSight.Web/Pages/Securities/Prices/Index.razor
@@ -133,7 +133,6 @@
 
     #endregion
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/SecurityExchanges/Index.razor
+++ b/NjordinSight.Web/Pages/SecurityExchanges/Index.razor
@@ -39,7 +39,6 @@
 </ThemedComponent>
 
 @code {
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         ActionMenu = new()

--- a/NjordinSight.Web/Pages/SecurityTypeGroups/Create.razor
+++ b/NjordinSight.Web/Pages/SecurityTypeGroups/Create.razor
@@ -43,13 +43,9 @@
 
 
 @code {
-    /// <summary>
-    /// Gets or sets the unique identifier for the creation action.
-    /// </summary>
     [Parameter]
     public Guid RequestGuid { get; init; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/SecurityTypeGroups/Detail.razor
+++ b/NjordinSight.Web/Pages/SecurityTypeGroups/Detail.razor
@@ -1,4 +1,4 @@
-﻿@page "/security-type-groups/{SecurityTypeGroupId:int}/detail"
+﻿@page "/security-type-groups/{ModelId:int}/detail"
 
 @inherits ModelDetail<SecurityTypeGroup>
 
@@ -32,20 +32,16 @@
 
 
 @code {
-    /// <summary>
-    /// Gets or sets the identifier for the <see cref="SecurityTypeGroup" /> worked using this page.
-    /// </summary>
     [Parameter]
-    public int SecurityTypeGroupId { get; set; }
+    public int ModelId { get; init; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;
 
         try
         {
-            var modelQuery = Controller.ReadAsync(SecurityTypeGroupId);
+            var modelQuery = Controller.ReadAsync(ModelId);
 
             if ((await modelQuery).Value is SecurityTypeGroup model)
                 Model = model;

--- a/NjordinSight.Web/Pages/SecurityTypeGroups/Edit.razor
+++ b/NjordinSight.Web/Pages/SecurityTypeGroups/Edit.razor
@@ -49,13 +49,9 @@
 
 
 @code {
-    /// <summary>
-    /// Gets or sets the identifier for the <see cref="SecurityTypeGroup" /> worked using this page.
-    /// </summary>
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/SecurityTypeGroups/Index.razor
+++ b/NjordinSight.Web/Pages/SecurityTypeGroups/Index.razor
@@ -51,7 +51,6 @@
 
 
 @code {
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         ActionMenu = GetDefaultIndexMenu();

--- a/NjordinSight.Web/Pages/SecurityTypes/Create.razor
+++ b/NjordinSight.Web/Pages/SecurityTypes/Create.razor
@@ -45,15 +45,11 @@
 
 
 @code {
-    /// <summary>
-    /// Gets or sets the unique identifier for the creation action.
-    /// </summary>
     [Parameter]
     public Guid RequestGuid { get; init; }
 
     private IEnumerable<LookupModel<int, string>> SecurityTypeGroups { get; set; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/SecurityTypes/Detail.razor
+++ b/NjordinSight.Web/Pages/SecurityTypes/Detail.razor
@@ -1,4 +1,4 @@
-﻿@page "/security-types/{SecurityTypeId:int}/detail"
+﻿@page "/security-types/{ModelId:int}/detail"
 
 @inherits ModelDetail<SecurityType>
 
@@ -33,22 +33,18 @@
 
 
 @code {
-    /// <summary>
-    /// Gets or sets the identifier for the <see cref="SecurityType" /> worked using this page.
-    /// </summary>
     [Parameter]
-    public int SecurityTypeId { get; set; }
+    public int ModelId { get; init; }
 
     private IEnumerable<LookupModel<int, string>> SecurityTypeGroups { get; set; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;
 
         try
         {
-            var modelQuery = Controller.ReadAsync(SecurityTypeId);
+            var modelQuery = Controller.ReadAsync(ModelId);
             var typeGroupsQuery = Controller.ReferenceQueries.GetSecurityTypeGroupDTOsAsync();
 
             Task dataTasks = Task.WhenAll(modelQuery, typeGroupsQuery);

--- a/NjordinSight.Web/Pages/SecurityTypes/Edit.razor
+++ b/NjordinSight.Web/Pages/SecurityTypes/Edit.razor
@@ -50,15 +50,11 @@
 
 
 @code {
-    /// <summary>
-    /// Gets or sets the identifier for the <see cref="SecurityType" /> worked using this page.
-    /// </summary>
     [Parameter]
-    public int ModelId { get; set; }
+    public int ModelId { get; init; }
 
     private IEnumerable<LookupModel<int, string>> SecurityTypeGroups { get; set; }
 
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;

--- a/NjordinSight.Web/Pages/SecurityTypes/Index.razor
+++ b/NjordinSight.Web/Pages/SecurityTypes/Index.razor
@@ -70,7 +70,6 @@
 
 
 @code {
-    /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
         ActionMenu = GetDefaultIndexMenu();


### PR DESCRIPTION
Change all route parameters for CRUD pages that use a model integer identifier to ModelId (later could be generalized further to 'id'). Clean-up unnecessary use of <inheritdoc/> tag for overriden methods.