### PR TITLE
Security-patch

### DIFF
--- a/NjordinSight.EntityModel/NjordinSight.EntityModel.csproj
+++ b/NjordinSight.EntityModel/NjordinSight.EntityModel.csproj
@@ -15,10 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="Ichosys.DataModel" Version="3.1.0.3791" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.16">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.16">

--- a/NjordinSight.EntityModel/NjordinSight.EntityModel.csproj
+++ b/NjordinSight.EntityModel/NjordinSight.EntityModel.csproj
@@ -17,10 +17,6 @@
     <PackageReference Include="Ichosys.DataModel" Version="3.1.0.3791" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.16" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.16">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/NjordinSight.EntityModel/NjordinSight.EntityModel.csproj
+++ b/NjordinSight.EntityModel/NjordinSight.EntityModel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ichosys.DataModel" Version="3.0.0.5515" />
+    <PackageReference Include="Ichosys.DataModel" Version="3.1.0.3791" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.16">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NjordinSight.Web/NjordinSight.Web.csproj
+++ b/NjordinSight.Web/NjordinSight.Web.csproj
@@ -30,7 +30,7 @@
 	<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.16" />
 	<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
 	<PackageReference Include="Serilog" Version="2.12.0" />
-	<PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
+	<PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
 	<PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
 	<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>

--- a/NjordinSight.Web/NjordinSight.Web.csproj
+++ b/NjordinSight.Web/NjordinSight.Web.csproj
@@ -33,7 +33,6 @@
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
 	<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
-	<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.13" />
 	<PackageReference Include="Serilog" Version="2.12.0" />
 	<PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
 	<PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />

--- a/NjordinSight.Web/NjordinSight.Web.csproj
+++ b/NjordinSight.Web/NjordinSight.Web.csproj
@@ -33,6 +33,10 @@
 	<PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
 	<PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
 	<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+
+	<!--This line forces a non-vulnerable version of System.Drawaing.Common to be included 
+		in the build. Without it, v4.7.0 is included. -->
+	<PackageReference Include="System.Drawing.Common" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NjordinSight.Web/NjordinSight.Web.csproj
+++ b/NjordinSight.Web/NjordinSight.Web.csproj
@@ -28,10 +28,6 @@
 	<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.16" />
 	<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.16" />
 	<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.16" />
-	<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.16">
-	  <PrivateAssets>all</PrivateAssets>
-	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	</PackageReference>
 	<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
 	<PackageReference Include="Serilog" Version="2.12.0" />
 	<PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />

--- a/NjordinSight.Web/NjordinSight.Web.csproj
+++ b/NjordinSight.Web/NjordinSight.Web.csproj
@@ -20,9 +20,9 @@
 	
   <ItemGroup>
 	<PackageReference Include="Ichosys.Blazor.Ionicons" Version="1.2.0.4133" />
-	<PackageReference Include="Ichosys.DataModel" Version="3.0.0.5515" />
-	<PackageReference Include="Ichosys.Extensions.Common" Version="1.4.0.4711" />
-	<PackageReference Include="Ichosys.Extensions.Configuration" Version="2.2.0" />
+	<PackageReference Include="Ichosys.DataModel" Version="3.1.0.3791" />
+	<PackageReference Include="Ichosys.Extensions.Common" Version="1.5.0.5645" />
+	<PackageReference Include="Ichosys.Extensions.Configuration" Version="2.3.1.4879" />
 	<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.16" />
 	<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.16" />
 	<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.16" />


### PR DESCRIPTION
### Fixes ###
* #148 

### Changes ###
* Update package dependencies where possible. Out-of-date libraries may require update .NET 7 target, so leaving be for now.