### PR TITLE
Fix error in FinanceDbIntegrationTestContext

### DIFF
--- a/NjordinSight.DAL.Test/TestUtility.cs
+++ b/NjordinSight.DAL.Test/TestUtility.cs
@@ -15,6 +15,20 @@ namespace NjordinSight.Test
     [TestClass]
     public class TestUtility
     {
+        static TestUtility()
+        {
+            Logger = LoggerFactory
+                .Create(builder => builder.AddConsole().AddDebug())
+                .CreateLogger<TestUtility>();
+
+            Configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.test.json")
+                .AddUserSecrets<TestUtility>()
+                .Build();
+
+            DbContextFactory = new();
+        }
+
         /// <summary>
         /// Resets the test database to its initial state.
         /// </summary>
@@ -25,23 +39,17 @@ namespace NjordinSight.Test
         /// <summary>
         /// Getst the configuration used by unit tests.
         /// </summary>
-        internal static IConfiguration Configuration { get; } =
-            new ConfigurationBuilder()
-            .AddJsonFile("appsettings.test.json")
-            .AddUserSecrets<TestUtility>()
-            .Build();
+        internal static IConfiguration Configuration { get; }
+            
+        /// <summary>
+        /// The <see cref="ILogger"/> instance for this project.
+        /// </summary>
+        internal static ILogger Logger { get; } 
 
         /// <summary>
         /// Gets the <see cref="IDbContextFactory{TContext}"/> for creating test contexts.
         /// </summary>
-        internal static TestDbContextFactory DbContextFactory { get; private set; } = new();
-
-        /// <summary>
-        /// The <see cref="ILogger"/> instance for this project.
-        /// </summary>
-        internal static readonly ILogger Logger = LoggerFactory
-            .Create(builder => builder.AddConsole().AddDebug())
-            .CreateLogger<TestUtility>();
+        internal static TestDbContextFactory DbContextFactory { get; }
 
         /// <summary>
         /// Checks public instance property values are equal two <typeparamref name="T"/> instances.

--- a/NjordinSight.EntityModel/Context/IntegrationTest/FinanceDbIntegrationTestContext.cs
+++ b/NjordinSight.EntityModel/Context/IntegrationTest/FinanceDbIntegrationTestContext.cs
@@ -187,7 +187,7 @@ namespace NjordinSight.EntityModel.Context.IntegrationTest
                 new() { AccountCompositeId = -8 }
             };
 
-            var AccountCompositeMembers = new AccountCompositeMember[]
+            var accountCompositeMembers = new AccountCompositeMember[]
             {
                 new()
                 {
@@ -602,25 +602,25 @@ namespace NjordinSight.EntityModel.Context.IntegrationTest
             {
                 new SecurityExchange()
                 {
-                    ExchangeId = -1,
-                    ExchangeCode = "NYSE",
-                    ExchangeDescription = "New York Stock Exchange"
+                    ExchangeId = -101,
+                    ExchangeCode = "MYSE",
+                    ExchangeDescription = "Mew York Stock Exchange"
                 },
                 new SecurityExchange()
                 {
-                    ExchangeId = -2,
-                    ExchangeCode = "NASDAQ",
+                    ExchangeId = -102,
+                    ExchangeCode = "NASQUACK",
                     ExchangeDescription = "Nasdaq Stock Market"
                 },
                 new()
                 {
-                    ExchangeId = -3,
+                    ExchangeId = -103,
                     ExchangeCode = "TestDeletePass",
                     ExchangeDescription = "Test delete pass"
                 },
                 new()
                 {
-                    ExchangeId = -4,
+                    ExchangeId = -104,
                     ExchangeCode = "TestUpdatePass",
                     ExchangeDescription = "Test update pass"
                 }
@@ -1308,7 +1308,12 @@ namespace NjordinSight.EntityModel.Context.IntegrationTest
             var sourceGuid = Guid.Parse("{81FEF80A-7C02-4483-80F5-A358A3598690}");
             IEntityConfiguration<T> newConfiguration<T>(params T[] entries)
                 where T : class
-                => new EntityConfiguration<T>(sourceGuid, entries);
+            {
+                if ((entries?.Length ?? 0) == 0)
+                    throw new ArgumentNullException(paramName: nameof(entries));
+                else
+                    return new EntityConfiguration<T>(sourceGuid, entries);
+            }
 
             targetCollection
                 .WithConfiguration(newConfiguration(accountCustodians))
@@ -1341,7 +1346,7 @@ namespace NjordinSight.EntityModel.Context.IntegrationTest
                 .WithConfiguration(newConfiguration(accounts))
                 .WithConfiguration(newConfiguration(accountWallets))
                 .WithConfiguration(newConfiguration(accountComposites))
-                .WithConfiguration(newConfiguration(AccountCompositeMembers))
+                .WithConfiguration(newConfiguration(accountCompositeMembers))
                 .WithConfiguration(newConfiguration(securities))
                 .WithConfiguration(newConfiguration(securitySymbols))
 


### PR DESCRIPTION
### Changes ###
* Fix error in `FinanceDbIntegrationTestContext` caused by conflicting primary key values
* Refactor `NjordinSight.DAL.Test.TestUtility` to use a static constructor for static property initialization.