### PR TITLE
refactor: remove unnecessary sealing

### DIFF
--- a/NjordinSight.DAL.Test/EntityModelService/TestDbContextFactory.cs
+++ b/NjordinSight.DAL.Test/EntityModelService/TestDbContextFactory.cs
@@ -9,7 +9,7 @@ namespace NjordinSight.Test.EntityModelService
     /// <summary>
     /// Implements <see cref="IDbContextFactory{TContext}"/> for testing model services.
     /// </summary>
-    internal sealed class TestDbContextFactory : IDbContextFactory<FinanceDbContext>
+    internal class TestDbContextFactory : IDbContextFactory<FinanceDbContext>
     {
         private static readonly object _lock = new();
         private static bool _databaseInitialized;

--- a/NjordinSight.DAL/EntityModelService/Abstractions/ModelReaderService.cs
+++ b/NjordinSight.DAL/EntityModelService/Abstractions/ModelReaderService.cs
@@ -16,7 +16,7 @@ namespace NjordinSight.EntityModelService.Abstractions
     /// Variant <see cref="ModelServiceBase{T}"/> class that services read and search requests.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    internal sealed partial class ModelReaderService<T> : ModelServiceBase<T>, IModelReaderService<T>
+    internal partial class ModelReaderService<T> : ModelServiceBase<T>, IModelReaderService<T>
         where T: class, new()
     {
         /// <summary>

--- a/NjordinSight.DAL/EntityModelService/Abstractions/ModelWriterService.cs
+++ b/NjordinSight.DAL/EntityModelService/Abstractions/ModelWriterService.cs
@@ -12,7 +12,7 @@ namespace NjordinSight.EntityModelService.Abstractions
     /// Variant <see cref="ModelServiceBase{T}"/> class that services write requests.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    internal sealed partial class ModelWriterService<T> : ModelServiceBase<T>, IModelWriterService<T>
+    internal partial class ModelWriterService<T> : ModelServiceBase<T>, IModelWriterService<T>
         where T : class, new()
     {
         /// <summary>

--- a/NjordinSight.DAL/EntityModelService/Query/QueryBuilder.cs
+++ b/NjordinSight.DAL/EntityModelService/Query/QueryBuilder.cs
@@ -17,7 +17,7 @@ namespace NjordinSight.EntityModelService.Query
     /// <remarks>
     /// Reltionship inclusions must be expressed in terms of <typeparamref name="TSource"/>.
     /// </remarks>
-    internal sealed partial class QueryBuilder<TSource> : IQueryBuilder<TSource>
+    internal partial class QueryBuilder<TSource> : IQueryBuilder<TSource>
         where TSource : class, new()
     {
         private readonly FinanceDbContext _context;
@@ -35,6 +35,8 @@ namespace NjordinSight.EntityModelService.Query
 
         ~QueryBuilder() => Dispose();
 
+        // TODO: Review this. Disposal for types resolved via dependency injection 
+        // is discourage. Adopt the same pattern as ModelSerivce classes?
         /// <inheritdoc/>
         public void Dispose()
         {
@@ -80,7 +82,7 @@ namespace NjordinSight.EntityModelService.Query
         private void QueryBuilder_QueryCompleted(object sender, EventArgs e) => _ = e;
     }
 
-    internal sealed partial class QueryBuilder<TSource> : IQueryDataStore<TSource>
+    internal partial class QueryBuilder<TSource> : IQueryDataStore<TSource>
     {
         /// <inheritdoc/>
         public IQueryDataStore<TSource> Build() => this;

--- a/NjordinSight.Web.Test/Identity/TestDbContextFactory.cs
+++ b/NjordinSight.Web.Test/Identity/TestDbContextFactory.cs
@@ -6,7 +6,7 @@ namespace NjordinSight.Web.Test.Identity
     /// <summary>
     /// Implements <see cref="IDbContextFactory{TContext}"/> for testing model services.
     /// </summary>
-    internal sealed class TestDbContextFactory : IDbContextFactory<IdentityDbContext>
+    internal class TestDbContextFactory : IDbContextFactory<IdentityDbContext>
     {
         private static readonly object _lock = new();
         private static bool _databaseInitialized;


### PR DESCRIPTION
### Changes ###
Removed improper sealing of classes. Recommendation is to not seal classes without reason, and none could be though of except for `DatabaseKey`, where inheritance and overriding the behavior could break its functionality.