### PR TITLE
fix: replace nameof captions with display strings and rename IViewHelper

### DIFF
--- a/NjordinSight.DAL/BusinessLogic/DisplayString.Designer.cs
+++ b/NjordinSight.DAL/BusinessLogic/DisplayString.Designer.cs
@@ -302,5 +302,95 @@ namespace NjordinSight.BusinessLogic {
                 return ResourceManager.GetString("FutureValueResult_Principal_Name", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unit change from last close price to most recent quote.
+        /// </summary>
+        public static string Quote_Change_Description {
+            get {
+                return ResourceManager.GetString("Quote_Change_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change.
+        /// </summary>
+        public static string Quote_Change_Name {
+            get {
+                return ResourceManager.GetString("Quote_Change_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Security/index description.
+        /// </summary>
+        public static string Quote_Description_Description {
+            get {
+                return ResourceManager.GetString("Quote_Description_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Description.
+        /// </summary>
+        public static string Quote_Description_Name {
+            get {
+                return ResourceManager.GetString("Quote_Description_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Most recent quoted price.
+        /// </summary>
+        public static string Quote_LastPrice_Description {
+            get {
+                return ResourceManager.GetString("Quote_LastPrice_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Last Price.
+        /// </summary>
+        public static string Quote_LastPrice_Name {
+            get {
+                return ResourceManager.GetString("Quote_LastPrice_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Percent change from last close price to most recent quote.
+        /// </summary>
+        public static string Quote_PercentChange_Description {
+            get {
+                return ResourceManager.GetString("Quote_PercentChange_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pct. Change.
+        /// </summary>
+        public static string Quote_PercentChange_Name {
+            get {
+                return ResourceManager.GetString("Quote_PercentChange_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Security/index identifier.
+        /// </summary>
+        public static string Quote_Symbol_Description {
+            get {
+                return ResourceManager.GetString("Quote_Symbol_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ticker.
+        /// </summary>
+        public static string Quote_Symbol_Name {
+            get {
+                return ResourceManager.GetString("Quote_Symbol_Name", resourceCulture);
+            }
+        }
     }
 }

--- a/NjordinSight.DAL/BusinessLogic/DisplayString.resx
+++ b/NjordinSight.DAL/BusinessLogic/DisplayString.resx
@@ -199,4 +199,34 @@
   <data name="FutureValueResult_Principal_Name" xml:space="preserve">
     <value>Principal</value>
   </data>
+  <data name="Quote_Change_Description" xml:space="preserve">
+    <value>Unit change from last close price to most recent quote</value>
+  </data>
+  <data name="Quote_Change_Name" xml:space="preserve">
+    <value>Change</value>
+  </data>
+  <data name="Quote_Description_Description" xml:space="preserve">
+    <value>Security/index description</value>
+  </data>
+  <data name="Quote_Description_Name" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="Quote_LastPrice_Description" xml:space="preserve">
+    <value>Most recent quoted price</value>
+  </data>
+  <data name="Quote_LastPrice_Name" xml:space="preserve">
+    <value>Last Price</value>
+  </data>
+  <data name="Quote_PercentChange_Description" xml:space="preserve">
+    <value>Percent change from last close price to most recent quote</value>
+  </data>
+  <data name="Quote_PercentChange_Name" xml:space="preserve">
+    <value>Pct. Change</value>
+  </data>
+  <data name="Quote_Symbol_Description" xml:space="preserve">
+    <value>Security/index identifier</value>
+  </data>
+  <data name="Quote_Symbol_Name" xml:space="preserve">
+    <value>Ticker</value>
+  </data>
 </root>

--- a/NjordinSight.DAL/BusinessLogic/MarketFeed/Quote.cs
+++ b/NjordinSight.DAL/BusinessLogic/MarketFeed/Quote.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -14,26 +15,46 @@ namespace NjordinSight.BusinessLogic.MarketFeed
         /// <summary>
         /// Gets or sets the exchange identifier of the security/index.
         /// </summary>
+        [Display(
+            Name = nameof(DisplayString.Quote_Symbol_Name),
+            Description = nameof(DisplayString.Quote_Symbol_Description),
+            ResourceType = typeof(DisplayString))]
         public string Symbol { get; init; }
 
         /// <summary>
         /// Gets or sets the description of the security/index.
         /// </summary>
+        [Display(
+            Name = nameof(DisplayString.Quote_Description_Name),
+            Description = nameof(DisplayString.Quote_Description_Description),
+            ResourceType = typeof(DisplayString))]
         public string Description { get; init; }
 
         /// <summary>
         /// Gets or sets the last price observed.
         /// </summary>
+        [Display(
+            Name = nameof(DisplayString.Quote_LastPrice_Name),
+            Description = nameof(DisplayString.Quote_LastPrice_Description),
+            ResourceType = typeof(DisplayString))]
         public double LastPrice { get; set; }
 
         /// <summary>
         /// Gets or sets the signed change from the previous quote.
         /// </summary>
+        [Display(
+            Name = nameof(DisplayString.Quote_Change_Name),
+            Description = nameof(DisplayString.Quote_Change_Description),
+            ResourceType = typeof(DisplayString))]
         public double Change { get; set; }
 
         /// <summary>
         /// Gets the signed proportional change from the previous quote.
         /// </summary>
+        [Display(
+            Name = nameof(DisplayString.Quote_PercentChange_Name),
+            Description = nameof(DisplayString.Quote_PercentChange_Description),
+            ResourceType = typeof(DisplayString))]
         public double PercentChange => Change / (LastPrice - Change);
     }
 }

--- a/NjordinSight.DAL/UserInterface/ITypedMetadataService.cs
+++ b/NjordinSight.DAL/UserInterface/ITypedMetadataService.cs
@@ -8,7 +8,7 @@ namespace NjordinSight.UserInterface
     /// Helpers class for simplifying calls to metadata get methods on a given type.
     /// </summary>
     /// <typeparam name="T">The model type in which metadata is defined.</typeparam>
-    public interface IViewHelper<T>
+    public interface ITypedMetadataService<T>
         where T : class
     {
         /// <summary>

--- a/NjordinSight.DAL/UserInterface/StringExtension.cs
+++ b/NjordinSight.DAL/UserInterface/StringExtension.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace NjordinSight.UserInterface
 {
-    public static class ViewHelperExtension
+    public static class StringExtension
     {
         /// <summary>
         /// The application name. Used as page title component.

--- a/NjordinSight.DAL/UserInterface/TypedMetadataService.cs
+++ b/NjordinSight.DAL/UserInterface/TypedMetadataService.cs
@@ -9,18 +9,18 @@ namespace NjordinSight.UserInterface
     /// syntax for querying metadata for type <typeparamref name="T"/>.
     /// </summary>
     /// <typeparam name="T">The type for which metadata is retrieved.</typeparam>
-    public class ViewHelper<T> : IViewHelper<T>
+    public class TypedMetadataService<T> : ITypedMetadataService<T>
         where T : class
     {
         private readonly IModelMetadataService _metadataService;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ViewHelper{T}"/> class.
+        /// Initializes a new instance of the <see cref="TypedMetadataService{T}"/> class.
         /// </summary>
         /// <param name="metadataService">The <see cref="IModelMetadataService"/> service for the 
         /// new instance.</param>
         /// <exception cref="ArgumentNullException">Parameter <paramref name="metadataService"/> was null.</exception>
-        public ViewHelper(IModelMetadataService metadataService)
+        public TypedMetadataService(IModelMetadataService metadataService)
         {
             if (metadataService is null)
                 throw new ArgumentNullException(paramName: nameof(metadataService));

--- a/NjordinSight.Web/Components/Dashboard/MarketQuoteTable.razor
+++ b/NjordinSight.Web/Components/Dashboard/MarketQuoteTable.razor
@@ -1,4 +1,6 @@
-﻿<div class="market-quote-table">
+﻿@inherits ModelComponent<Quote>
+
+<div class="market-quote-table">
     @if(Quotes is null)
     {
         <LoadingSvg />
@@ -8,28 +10,28 @@
         <DataGrid Data="Quotes">
             <DataGridColumn 
                 Type="DataGridCellType.Text"
-                Property="@nameof(Quote.Symbol)" Caption="@nameof(Quote.Symbol)">
+                Property="@nameof(Quote.Symbol)" Caption="@NameFor(x => x.Symbol)">
                 <CellTemplate Context="model">
                         @model.Symbol
                 </CellTemplate>
             </DataGridColumn>
             <DataGridColumn 
                 Type="DataGridCellType.Text"
-                Property="@nameof(Quote.Description)" Caption="@nameof(Quote.Description)">
+                Property="@nameof(Quote.Description)" Caption="@NameFor(x => x.Description)">
                 <CellTemplate Context="model">
                         @model.Description
                 </CellTemplate>
             </DataGridColumn>
             <DataGridColumn 
                 Type="DataGridCellType.Text"
-                Property="@nameof(Quote.LastPrice)" Caption="@nameof(Quote.LastPrice)">
+                Property="@nameof(Quote.LastPrice)" Caption="@NameFor(x => x.LastPrice)">
                 <CellTemplate Context="model">
                         @model.LastPrice.ToString("C2")
                 </CellTemplate>
             </DataGridColumn>
             <DataGridColumn 
                 Type="DataGridCellType.Text"
-                            Property="@nameof(Quote.Change)" Caption="@nameof(Quote.Change)">
+                Property="@nameof(Quote.Change)" Caption="@NameFor(x => x.Change)">
                 <CellTemplate Context="model">
                     <div class="@(IsNegativeClass(model.Change))">
                         @model.Change.ToString("C2")
@@ -38,7 +40,7 @@
             </DataGridColumn>
             <DataGridColumn 
                 Type="DataGridCellType.Text"
-                Property="@nameof(Quote.PercentChange)" Caption="@nameof(Quote.PercentChange)">
+                Property="@nameof(Quote.PercentChange)" Caption="@NameFor(x => x.PercentChange)">
                 <CellTemplate Context="model">
                     <div class="@(IsNegativeClass(model.Change))">
                         @model.PercentChange.ToString("P2")

--- a/NjordinSight.Web/Components/Generic/ModelComponent.razor
+++ b/NjordinSight.Web/Components/Generic/ModelComponent.razor
@@ -3,7 +3,7 @@
 @inherits LocalizableComponent
 
 @code {
-    private IViewHelper<TModelDto> _viewHelper;
+    private ITypedMetadataService<TModelDto> _typedMetadataHelper;
 
     /// <summary>
     /// Gets the description text for select <typeparamref name="TModelDto"/> member.
@@ -11,7 +11,7 @@
     /// <param name="expression">The expression indicated the member to retrieve metadata for.</param>
     /// <returns>A <see cref="string"/> representing the description if defined, else null.</returns>
     protected string DescriptionFor(Expression<Func<TModelDto, object>> expression)
-        => ViewHelper.DescriptionFor(expression);
+        => TypedMetdataHelper.DescriptionFor(expression);
 
     /// <summary>
     /// Gets the group name for select <typeparamref name="TModelDto"/> member.
@@ -19,7 +19,7 @@
     /// <param name="expression">The expression indicated the member to retrieve metadata for.</param>
     /// <returns>A <see cref="string"/> representing the description if defined, else null.</returns>
     protected string GroupNameFor(Expression<Func<TModelDto, object>> expression)
-        => ViewHelper.GroupNameFor(expression);
+        => TypedMetdataHelper.GroupNameFor(expression);
 
     /// <summary>
     /// Gets the name for select <typeparamref name="TModelDto"/> member.
@@ -27,7 +27,7 @@
     /// <param name="expression">The expression indicated the member to retrieve metadata for.</param>
     /// <returns>A <see cref="string"/> representing the name if defined, else null.</returns>
     protected string NameFor(Expression<Func<TModelDto, object>> expression)
-        => ViewHelper.NameFor(expression);
+        => TypedMetdataHelper.NameFor(expression);
 
     /// <summary>
     /// Gets the display order for select <typeparamref name="TModelDto"/> member.
@@ -35,7 +35,7 @@
     /// <param name="expression">The expression indicated the member to retrieve metadata for.</param>
     /// <returns>A <see cref="int"/> representing the display order if defined, else null.</returns>
     protected int? OrderFor(Expression<Func<TModelDto, object>> expression)
-        => ViewHelper.OrderFor(expression);
+        => TypedMetdataHelper.OrderFor(expression);
 
     /// <summary>
     /// Gets the input prompt text for select <typeparamref name="TModelDto"/> member.
@@ -43,7 +43,7 @@
     /// <param name="expression">The expression indicated the member to retrieve metadata for.</param>
     /// <returns>A <see cref="string"/> representing the input prompt if defined, else null.</returns>
     protected string PromptFor(Expression<Func<TModelDto, object>> expression)
-        => ViewHelper.PromptFor(expression);
+        => TypedMetdataHelper.PromptFor(expression);
 
     /// <summary>
     /// Gets the short name text for select <typeparamref name="TModelDto"/> member.
@@ -51,17 +51,17 @@
     /// <param name="expression">The expression indicated the member to retrieve metadata for.</param>
     /// <returns>A <see cref="string"/> representing the short name if defined, else null.</returns>
     protected string ShortNameFor(Expression<Func<TModelDto, object>> expression)
-            => ViewHelper.ShortNameFor(expression);
+            => TypedMetdataHelper.ShortNameFor(expression);
 
     /// <summary>
-    /// Gets the <see cref="IViewHelper{T}"/> instance for this component's type.
+    /// Gets the <see cref="ITypedMetadataService{T}"/> instance for this component's type.
     /// </summary>
-    public IViewHelper<TModelDto> ViewHelper
+    public ITypedMetadataService<TModelDto> TypedMetdataHelper
     {
         get
         {
-            _viewHelper ??= new ViewHelper<TModelDto>(ModelMetadata);
-            return _viewHelper;
+            _typedMetadataHelper ??= new TypedMetadataService<TModelDto>(ModelMetadata);
+            return _typedMetadataHelper;
         }
     }
 }

--- a/NjordinSight.Web/Program.cs
+++ b/NjordinSight.Web/Program.cs
@@ -98,7 +98,7 @@ builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 // Add metadata, search, and message services.
 builder.Services.AddSingleton<IExpressionBuilder, ExpressionBuilder>();
 builder.Services.AddSingleton<IModelMetadataService, ModelMetadataService>();
-builder.Services.AddSingleton(typeof(IViewHelper<>), typeof(ViewHelper<>));
+builder.Services.AddSingleton(typeof(ITypedMetadataService<>), typeof(TypedMetadataService<>));
 
 builder.Services.AddTransient(typeof(ISearchService<>), typeof(SearchService<>));
 


### PR DESCRIPTION
Replace 'nameof' use in dashboard market quote content with proper display text values accessed view IViewHelper.
Rename IViewHelper interface and ViewHelper class to ITypedMetadataService to clarify their intended purposes.