### PR TITLE
Add basic HTTP service for Razor components

### DIFF
--- a/NjordinSight.API/Controllers/ApiController.cs
+++ b/NjordinSight.API/Controllers/ApiController.cs
@@ -130,7 +130,7 @@ namespace NjordinSight.Api.Controllers
             Expression<Func<TEntity, bool>> entityPredicate;
 
             // If query parameter is invalid use the default filter expression.
-            if (!queryParameter.IsValid)
+            if (!(queryParameter?.IsValid ?? false))
             {
                 entityPredicate = x => true;
             }

--- a/NjordinSight.API/Controllers/ApiController.cs
+++ b/NjordinSight.API/Controllers/ApiController.cs
@@ -108,6 +108,7 @@ namespace NjordinSight.Api.Controllers
         }
 
         /// <inheritdoc/>
+        [Obsolete("Retained for backwards compatability. Use PostSearchAsync instead.")]
         [HttpGet]
         public virtual async Task<ActionResult<IEnumerable<TObject>>> GetAsync(
             [FromBody] ParameterDto<TObject> queryParameter, int pageNumber = 1, int pageSize = 20)

--- a/NjordinSight.API/Controllers/IApiController.cs
+++ b/NjordinSight.API/Controllers/IApiController.cs
@@ -1,6 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using MathNet.Numerics.Statistics.Mcmc;
+using Microsoft.AspNetCore.Mvc;
 using NjordinSight.DataTransfer.Common.Query;
+using NjordinSight.EntityModelService;
+using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 
 namespace NjordinSight.Api.Controllers
@@ -11,21 +15,76 @@ namespace NjordinSight.Api.Controllers
     /// <typeparam name="TObject"></typeparam>
     public interface IApiController<TObject>
     {
-    #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+        /// <summary>
+        /// Submits a deletion request for the resource identified by the given id.
+        /// </summary>
+        /// <param name="id">The unique identifier for the resource to delete.</param>
+        /// <returns>An <see cref="IActionResult"/> representing the response. 204 No Content is 
+        /// returned if the requested completed successfully.</returns>
         Task<IActionResult> DeleteAsync(int id);
 
+        /// <summary>
+        /// Retrieves the resource identified by the given id.
+        /// </summary>
+        /// <param name="id">The unique identifier for the resource to retrieve.</param>
+        /// <returns></returns>
         Task<ActionResult<TObject>> GetAsync(int id);
-        
+
+        /// <summary>
+        /// Retrieves the collection matching the given query parameter, limited to the given 
+        /// page index and size parameters.
+        /// </summary>
+        /// <param name="queryParameter">The <see cref="ParameterDto{T}"/> describing the operation 
+        /// to filter results.</param>
+        /// <param name="pageNumber">The index of page to retrieve.</param>
+        /// <param name="pageSize">The record limit for each page.</param>
+        /// <returns>An <see cref="ActionResult{TValue}"/> whose value is an enumerable collection 
+        /// of <typeparamref name="TObject"/> instances.</returns>
         Task<ActionResult<IEnumerable<TObject>>> GetAsync(
             [FromBody] ParameterDto<TObject> queryParameter, 
             int pageNumber = 1, 
             int pageSize = 20);
 
+        /// <summary>
+        /// Initializes a default instance for use in a post action.
+        /// </summary>
+        /// <returns>An <see cref="ActionResult{TValue}"/> whose value is the initialized 
+        /// <typeparamref name="TObject"/>.</returns>
         Task<ActionResult<TObject>> InitDefaultAsync();
 
+        /// <summary>
+        /// Submits a post request to insert the given <typeparamref name="TObject"/> to the data 
+        /// store.
+        /// </summary>
+        /// <param name="model">The instance to create.</param>
+        /// <returns>The updated <typeparamref name="TObject"/> instance.</returns>
         Task<ActionResult<TObject>> PostAsync(TObject model);
 
+        /// <summary>
+        /// Submits a put request to replace the resource matching the given id with the model
+        /// instance given.
+        /// </summary>
+        /// <param name="id">The unique identifier for the resource to replace.</param>
+        /// <param name="model">The instance to replace the existing resource.</param>
+        /// <returns></returns>
+        /// <remarks>Only PUT methods are supported for updating records. PATCH method is 
+        /// planned.</remarks>
         Task<ActionResult<TObject>> PutAsync(int id, TObject model);
-    #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+
+        /// <summary>
+        /// Posts the search expression in the request body and returns the <typeparamref name="TObject"/> 
+        /// records matching the expression, limited to the page index and size
+        /// </summary>
+        /// <param name="queryParameter">The <see cref="ParameterDto{T}"/> describing the operation 
+        /// to filter results.</param>
+        /// <param name="pageNumber">The index of page to retrieve.</param>
+        /// <param name="pageSize">The record limit for each page.</param>
+        /// <returns>An <see cref="ActionResult{TValue}"/> whose value is an enumerable collection 
+        /// of <typeparamref name="TObject"/> instances.</returns>
+        /// <remarks>This method works around using GET methods with filters defined in the URI.
+        /// Use this method to pass search parameters to the endpoint [controller]/search, where the
+        /// response content gives the filtered result set.</remarks>
+        Task<ActionResult<IEnumerable<TObject>>> PostSearchAsync(
+            [FromBody] ParameterDto<TObject> queryParameter, int pageNumber = 1, int pageSize = 20);
     }
 }

--- a/NjordinSight.API/Program.cs
+++ b/NjordinSight.API/Program.cs
@@ -15,7 +15,6 @@ namespace NjordinSight.Api
 {
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public class Program
-
     {
         public static void Main(string[] args)
         {
@@ -77,6 +76,8 @@ namespace NjordinSight.Api
         /// Builds the application <see cref="IConfiguration"/> instance.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to use.</param>
+        /// <param name="configureSecureJson">Whether the application should configuration an 
+        /// encrypted JSON configuration provider.</param>
         /// <returns>An <see cref="IConfiguration"/>.</returns>
         private static IConfigurationRoot BuildConfiguration(
             ILogger logger, bool configureSecureJson = true)

--- a/NjordinSight.Web/IServiceCollectionExtWeb.cs
+++ b/NjordinSight.Web/IServiceCollectionExtWeb.cs
@@ -18,6 +18,8 @@ using NjordinSight.Messaging;
 using NjordinSight.UserInterface;
 using Ichosys.Blazor.Ionicons;
 using System.Xml.Serialization;
+using System.Reflection;
+using System.Net.Http;
 
 namespace NjordinSight.Web
 {
@@ -109,6 +111,20 @@ namespace NjordinSight.Web
                 .AddScoped<
                     ICollectionController<SecurityPrice>, 
                     ModelCollectionController<SecurityPrice>>();
+
+            return services;
+        }
+
+        /// <summary>
+        /// Registers <see cref="IHttpClientFactory"/> and <see cref="IHttpService{T}"/> services.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <returns>A reference to this instance after the operation is completed.</returns>
+        /// <remarks>
+        public static IServiceCollection AddHttpServices(this IServiceCollection services)
+        {
+            services.AddHttpClient();
+            services.AddTransient(typeof(IHttpService<>), typeof(HttpService<>));
 
             return services;
         }

--- a/NjordinSight.Web/Pages/Accounts/Index.razor
+++ b/NjordinSight.Web/Pages/Accounts/Index.razor
@@ -127,6 +127,16 @@
 
 
 @code {
+    [Inject]
+    protected IHttpService<NjordinSight.DataTransfer.Common.AccountDto> HttpService { get; init; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+
+        var response = await HttpService.SelectAsync();
+    }
+
     private void Detail_OnClick(Account model, MouseEventArgs args)
     {
         NavigationHelper.NavigateTo(FormatDetailUri(model.AccountId));

--- a/NjordinSight.Web/Program.cs
+++ b/NjordinSight.Web/Program.cs
@@ -24,156 +24,169 @@ using Microsoft.AspNetCore.Hosting;
 using NjordinSight.UserInterface;
 using NjordinSight.Web.Services;
 using NjordinSight.BusinessLogic.Functions;
+using System.Reflection;
+using System.Linq;
 
-var builder = WebApplication.CreateBuilder(args);
-
-// Register services for dependency injection
-#region Configuration, Logger, Helper services
-
-var databaseProvider = builder.Configuration["DATABASE_PROVIDER"];
-
-var logger = ConvertFromSerilogILogger(logger: BuildLogger());
-var config = BuildConfiguration(logger, databaseProvider == "SQL_SERVER");
-
-builder.Services.AddSingleton(implementationInstance: logger);
-builder.Services.AddSingleton(implementationInstance: config);
-
-#endregion
-
-builder.AddIdentityContextFactoryService(databaseProvider);
-
-#region Authentication configuration
-
-builder.Services.AddDefaultIdentity<WebAppUser>(options => options.SignIn.RequireConfirmedAccount = false)
-    .AddEntityFrameworkStores<IdentityDbContext>();
-
-builder.Services
-    .AddScoped<AuthenticationStateProvider, RevalidatingIdentityAuthenticationStateProvider<WebAppUser>>();
-
-builder.Services.AddDatabaseDeveloperPageExceptionFilter();
-
-#endregion
-
-// DAL services
-builder.Services.AddDataAccessServices(
-    databaseProvider: databaseProvider,
-    developerMode: builder.Environment.IsDevelopment());
-
-// Blazor app services
-builder.Services.AddBlazorPageServices();
-
-builder.Services.AddRazorPages();
-builder.Services.AddServerSideBlazor();
-
-var app = builder.Build();
-
-// Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
+namespace NjordinSight.Web
 {
-    app.UseMigrationsEndPoint();
-}
-else
-{
-    app.UseExceptionHandler("/Error");
-    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-    app.UseHsts();
-}
-
-app.UseHttpsRedirection();
-
-app.UseStaticFiles();
-
-app.UseRouting();
-
-// Configure to use authentication/authorization.
-app.UseAuthentication();
-app.UseAuthorization();
-
-app.MapControllers();
-app.MapBlazorHub();
-app.MapFallbackToPage("/_Host");
-
-app.Run();
-
-partial class Program
-{
-    /// <summary>
-    /// Builds the application <see cref="ILogger"/> instance.
-    /// </summary>
-    /// <returns>A <see cref="Serilog.ILogger"/>.</returns>
-    private static Serilog.ILogger BuildLogger()
+    public partial class Program
     {
-        // Define logger settings.
-        Log.Logger = new LoggerConfiguration()
-            .Enrich.FromLogContext()
-            .MinimumLevel.Information()
-            .MinimumLevel.Override("Microsoft", Serilog.Events.LogEventLevel.Information)
-            .WriteTo.File(
-                path: $"{NjordinSight.Configuration.AssemblyInfo.ExecutingAssemblyPath}\\logs\\.log",
-                rollingInterval: RollingInterval.Day,
-                shared: true)
-            .WriteTo.File(
-                formatter: new RenderedCompactJsonFormatter(),
-                path: $"{NjordinSight.Configuration.AssemblyInfo.ExecutingAssemblyPath}\\logs\\.json",
-                rollingInterval: RollingInterval.Day,
-                shared: true)
-            .CreateLogger();
-
-        return Log.Logger;
-    }
-
-    /// <summary>
-    /// Builds the application <see cref="IConfiguration"/> instance.
-    /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to use.</param>
-    /// <returns>An <see cref="IConfiguration"/>.</returns>
-    private static IConfigurationRoot BuildConfiguration(ILogger logger, bool configureSecureJson = true)
-    {
-        IConfigurationRoot config;
-        if(configureSecureJson)
+        public static void Main(string[] args)
         {
-            config = new ConfigurationBuilder()
-            .AddSecureJsonWritable(
-                path: "appsettings.Development.json",
-                logger: logger,
-                optional: false,
-                reloadOnChange: true)
-            .AddUserSecrets<Program>()
-            .Build();
+            var builder = WebApplication.CreateBuilder(args);
 
-            string rsaKeyAddress = "_file:RsaKeyContainer";
-            if (config[rsaKeyAddress] is null)
+            // Register services for dependency injection
+            #region Configuration, Logger, Helper services
+
+            var databaseProvider = builder.Configuration["DATABASE_PROVIDER"];
+
+            var logger = ConvertFromSerilogILogger(logger: BuildLogger());
+            var config = BuildConfiguration(logger, databaseProvider == "SQL_SERVER");
+
+            builder.Services.AddSingleton(implementationInstance: logger);
+            builder.Services.AddSingleton(implementationInstance: config);
+
+            #endregion
+
+            builder.AddIdentityContextFactoryService(databaseProvider);
+
+            #region Authentication configuration
+
+            builder.Services.AddDefaultIdentity<WebAppUser>(options => options.SignIn.RequireConfirmedAccount = false)
+                .AddEntityFrameworkStores<IdentityDbContext>();
+
+            builder.Services
+                .AddScoped<AuthenticationStateProvider, RevalidatingIdentityAuthenticationStateProvider<WebAppUser>>();
+
+            builder.Services.AddDatabaseDeveloperPageExceptionFilter();
+
+            #endregion
+
+            // DAL services
+            builder.Services.AddDataAccessServices(
+                databaseProvider: databaseProvider,
+                developerMode: builder.Environment.IsDevelopment());
+
+            // Blazor app services
+            builder.Services.AddBlazorPageServices();
+
+            builder.Services.AddRazorPages();
+            builder.Services.AddServerSideBlazor();
+
+            builder.Services.AddHttpServices();
+
+            var app = builder.Build();
+
+            // Configure the HTTP request pipeline.
+            if (app.Environment.IsDevelopment())
             {
-                config[rsaKeyAddress] = $"E1EB57FA-8D2C-41CF-912A-DDBC39534A39";
-                config.Commit();
+                app.UseMigrationsEndPoint();
+            }
+            else
+            {
+                app.UseExceptionHandler("/Error");
+                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+                app.UseHsts();
             }
 
-            config["ConnectionStrings:NjordWorks"] = config["ConnectionStrings:NjordWorks"];
-            config["ConnectionStrings:NjordIdentity"] = config["ConnectionStrings:NjordIdentity"];
-            config.Commit();
+            app.UseHttpsRedirection();
+
+            app.UseStaticFiles();
+
+            app.UseRouting();
+
+            // Configure to use authentication/authorization.
+            app.UseAuthentication();
+            app.UseAuthorization();
+
+            app.MapControllers();
+
+            app.MapBlazorHub();
+            app.MapFallbackToPage("/_Host");
+
+            app.Run();
+
         }
-        else
+    }
+
+    public partial class Program
+    {
+        /// <summary>
+        /// Builds the application <see cref="ILogger"/> instance.
+        /// </summary>
+        /// <returns>A <see cref="Serilog.ILogger"/>.</returns>
+        private static Serilog.ILogger BuildLogger()
         {
-            config = new ConfigurationBuilder()
-                .AddJsonWritable(
+            // Define logger settings.
+            Log.Logger = new LoggerConfiguration()
+                .Enrich.FromLogContext()
+                .MinimumLevel.Information()
+                .MinimumLevel.Override("Microsoft", Serilog.Events.LogEventLevel.Information)
+                .WriteTo.File(
+                    path: $"{NjordinSight.Configuration.AssemblyInfo.ExecutingAssemblyPath}\\logs\\.log",
+                    rollingInterval: RollingInterval.Day,
+                    shared: true)
+                .WriteTo.File(
+                    formatter: new RenderedCompactJsonFormatter(),
+                    path: $"{NjordinSight.Configuration.AssemblyInfo.ExecutingAssemblyPath}\\logs\\.json",
+                    rollingInterval: RollingInterval.Day,
+                    shared: true)
+                .CreateLogger();
+
+            return Log.Logger;
+        }
+
+        /// <summary>
+        /// Builds the application <see cref="IConfiguration"/> instance.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/> to use.</param>
+        /// <returns>An <see cref="IConfiguration"/>.</returns>
+        private static IConfigurationRoot BuildConfiguration(ILogger logger, bool configureSecureJson = true)
+        {
+            IConfigurationRoot config;
+            if(configureSecureJson)
+            {
+                config = new ConfigurationBuilder()
+                .AddSecureJsonWritable(
                     path: "appsettings.Development.json",
+                    logger: logger,
                     optional: false,
                     reloadOnChange: true)
+                .AddUserSecrets<Program>()
                 .Build();
+
+                string rsaKeyAddress = "_file:RsaKeyContainer";
+                if (config[rsaKeyAddress] is null)
+                {
+                    config[rsaKeyAddress] = $"E1EB57FA-8D2C-41CF-912A-DDBC39534A39";
+                    config.Commit();
+                }
+
+                config["ConnectionStrings:NjordWorks"] = config["ConnectionStrings:NjordWorks"];
+                config["ConnectionStrings:NjordIdentity"] = config["ConnectionStrings:NjordIdentity"];
+                config.Commit();
+            }
+            else
+            {
+                config = new ConfigurationBuilder()
+                    .AddJsonWritable(
+                        path: "appsettings.Development.json",
+                        optional: false,
+                        reloadOnChange: true)
+                    .Build();
+            }
+
+            return config;
         }
-
-        return config;
-    }
     
-    /// <summary>
-    /// Converts a <see cref="Serilog.ILogger"/> instance to a <see cref="ILogger"/> instance.
-    /// </summary>
-    /// <param name="logger"></param>
-    /// <returns>A <see cref="ILogger"/>.</returns>
-    private static ILogger ConvertFromSerilogILogger(Serilog.ILogger logger)
-    {
-        return new SerilogLoggerFactory(logger).CreateLogger(nameof(Program));
+        /// <summary>
+        /// Converts a <see cref="Serilog.ILogger"/> instance to a <see cref="ILogger"/> instance.
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <returns>A <see cref="ILogger"/>.</returns>
+        private static ILogger ConvertFromSerilogILogger(Serilog.ILogger logger)
+        {
+            return new SerilogLoggerFactory(logger).CreateLogger(nameof(Program));
+        }
     }
-
-    
 }

--- a/NjordinSight.Web/Services/ApiOptions.cs
+++ b/NjordinSight.Web/Services/ApiOptions.cs
@@ -1,0 +1,11 @@
+﻿namespace NjordinSight.Web.Services
+{
+    public class ApiOptions
+    {
+        public const string ApiService = nameof(ApiService);
+
+        public string Name { get; init; }
+
+        public string Url { get; set; }
+    }
+}

--- a/NjordinSight.Web/Services/HttpService.cs
+++ b/NjordinSight.Web/Services/HttpService.cs
@@ -1,0 +1,181 @@
+﻿using Microsoft.AspNetCore.Components;
+using NjordinSight.DataTransfer;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Net.Mime;
+using System.Text.Json;
+using System.Text;
+using System.Threading.Tasks;
+using NjordinSight.DataTransfer.Common.Query;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace NjordinSight.Web.Services
+{
+    /// <summary>
+    /// Interface representing methods for interacting with a RESTful web api.
+    /// </summary>
+    public interface IHttpService<T>
+    {
+        /// <summary>
+        /// Deletes the <typeparamref name="T"/> resource matching the given identifier.
+        /// </summary>
+        /// <param name="id">Identifer of the resource to delete.</param>
+        /// <returns>Task representing a completed deletion request.</returns>
+        Task DeleteAsync(int id);
+
+        /// <summary>
+        /// Gets the <typeparamref name="T"/> resource matching the given identifier.
+        /// </summary>
+        /// <param name="id">The integer key to match.</param>
+        /// <returns>The <typeparamref name="T"/> identified by <paramref name="id"/>.</returns>
+        Task<T> GetAsync(int? id);
+
+        /// <summary>
+        /// Creates a default instance of <typeparamref name="T"/>.
+        /// </summary>
+        /// <returns>An instance of <typeparamref name="T"/>.
+        Task<T> InitDefaultAsync();
+
+        /// <summary>
+        /// Posts the given <typeparamref name="T"/> resource to the data store.
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns>A task containing the <see cref="Uri"/> for the created resource.</returns>
+        Task<Uri> PostAysnc(T model);
+
+        /// <summary>
+        /// Replaces the <typeparamref name="T"/> resource matching the given identifier.
+        /// </summary>
+        /// <param name="model">The <typeparamref name="T"/> model to update.</param>
+        /// <returns>A task containing the <see cref="Uri"/> for the created resource.</returns>
+        Task<Uri> PutAsync(int? id, T model);
+
+        /// <summary>
+        /// Selects records matching the given <paramref name="predicate"/>, limited to the given
+        /// page index, and page size.
+        /// </summary>
+        /// <param name="queryParameter"><see cref="ParameterDto{T}"/> to filter results.</param>
+        /// <param name="pageNumber">Number of the page of results to return.</param>
+        /// <param name="pageSize">Limit to records returned in a single page.</param>
+        /// <returns>A task containing the <see cref="IEnumerable{T}"/> of <typeparamref name="T"/> 
+        /// matching the given predication and page parameters.</returns>
+        Task<IEnumerable<T>> SelectAsync(
+            ParameterDto<T> queryParameter = null, int pageNumber = 1, int pageSize = 20);
+
+        /// <summary>
+        /// Calls navigation to the index page for the <typeparamref name="T"/> resource store.
+        /// </summary>
+        void NavigateToIndex();
+    }
+
+    /// <summary>
+    /// Service class responsible for managing HTTP requests via a web API service and navigation 
+    /// via URI.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class HttpService<T> : IHttpService<T>
+    {
+#pragma warning disable IDE0052 // Remove unread private members
+        private readonly IHttpClientFactory _httpFactory;
+        private readonly NavigationManager _navigationManager;
+#pragma warning restore IDE0052 // Remove unread private members
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="IHttpService{T}"/>.
+        /// </summary>
+        /// <param name="httpFactory"></param>
+        /// <param name="navigationManager"></param>
+        public HttpService(IHttpClientFactory httpFactory, NavigationManager navigationManager)
+        {
+            if (httpFactory is null)
+                throw new ArgumentNullException(paramName: nameof(httpFactory));
+
+            if (navigationManager is null)
+                throw new ArgumentNullException(paramName: nameof(navigationManager));
+
+            _httpFactory = httpFactory;
+            _navigationManager = navigationManager;
+        }
+
+        /// <summary>
+        /// Gets or sets the base URI for this web service.
+        /// </summary>
+        private string BaseUri { get; init; }
+
+        /// <inheritdoc/>
+        public async Task<T> GetAsync(int? id)
+        {
+            using var client = _httpFactory.CreateClient();
+
+            return await client.GetFromJsonAsync<T>($"{BaseUri}/{id}");
+        }
+
+        /// <inheritdoc/>
+        public async Task DeleteAsync(int id)
+        {
+            using var client = _httpFactory.CreateClient();
+
+            var httpResponse =  await client.DeleteAsync($"{BaseUri}/{id}");
+
+            httpResponse.EnsureSuccessStatusCode();
+        }
+
+        /// <inheritdoc/>
+        public async Task<T> InitDefaultAsync()
+        {
+            using var client = _httpFactory.CreateClient();
+
+            return await client.GetFromJsonAsync<T>($"{BaseUri}/init");
+        }
+        
+        /// <inheritdoc/>
+        public async Task<Uri> PostAysnc(T model)
+        {
+            using var client = _httpFactory.CreateClient();
+
+            var httpResponse = await client.PostAsJsonAsync(
+                requestUri: $"{BaseUri}", model, options: new(JsonSerializerDefaults.Web));
+
+            httpResponse.EnsureSuccessStatusCode();
+
+            return httpResponse.Headers.Location;
+        }
+
+        /// <inheritdoc/>
+        public async Task<Uri> PutAsync(int? id, T model)
+        {
+            using var client = _httpFactory.CreateClient();
+
+            var httpResponse = await client.PutAsJsonAsync(
+                requestUri: $"{BaseUri}", model, options: new(JsonSerializerDefaults.Web));
+
+            httpResponse.EnsureSuccessStatusCode();
+
+            return httpResponse.Headers.Location;
+        }
+
+        /// <inheritdoc/>
+        public async Task<IEnumerable<T>> SelectAsync(
+            #pragma warning disable IDE0060 // Remove unused parameter
+            ParameterDto<T> queryParameter, int pageNumber = 1, int pageSize = 20)
+            #pragma warning restore IDE0060 // Remove unused parameter
+        {
+            // TODO: Convert methods to have query parameter be passed in the URI string. 
+            // For now no filter parameters will be provided.
+
+            //var jsonContent = JsonContent.Create(
+            //    queryParameter, options: new(JsonSerializerDefaults.Web));
+            
+            using var client = _httpFactory.CreateClient();
+
+            return await client.GetFromJsonAsync<IEnumerable<T>>(
+                requestUri: $"{BaseUri}?pageNumber={pageNumber}&pageSize={pageSize}");
+        }
+
+        /// <inheritdoc/>
+        public void NavigateToIndex() => _navigationManager.NavigateTo(BaseUri, replace: true);
+    }
+}


### PR DESCRIPTION
### Changes ###
Add basic HTTP service to wrap HTTP request/response handling to avoid code re-use in Razor components. Also helps testing incorporating API calls into pages in lieu of using custom `IController` class.